### PR TITLE
Fixed action key to task key value mapping during task execution

### DIFF
--- a/controlplane/plane_test.go
+++ b/controlplane/plane_test.go
@@ -14,23 +14,29 @@ import (
 // Test cases to verify the implementation
 func TestExtractDependencyID(t *testing.T) {
 	testCases := []struct {
-		name     string
-		input    any
-		expected string
+		name           string
+		input          any
+		expectedDepID  string
+		expectedDepKey string
 	}{
-		{"has dependency id", "$task0.param1", "task0"},
-		{"has complex dependency id", "$complex-task-id.field", "complex-task-id"},
-		{"has no dependency", "notadependency", ""},
-		{"has invalid dependency", "$.invalid", ""},
-		{"has dependency but no param", "$task0", ""},
-		{"empty input", "", ""},
+		{"has dependency id", "$task0.param1", "task0", "param1"},
+		{"has complex dependency id", "$complex-task-id.field", "complex-task-id", "field"},
+		{"has no dependency", "notadependency", "", ""},
+		{"has invalid dependency", "$.invalid", "", ""},
+		{"has dependency but no param", "$task0", "", ""},
+		{"empty input", "", "", ""},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := extractDependencyID(tc.input)
-			if actual != tc.expected {
-				panic(fmt.Sprintf("Failed: input=%q, got=%q, want=%q", tc.input, actual, tc.expected))
+			actualDepID, actualDepKey := extractDependencyIDAndKey(tc.input)
+			if actualDepID != tc.expectedDepID {
+				panic(fmt.Sprintf("Failed: input=%q, got=(%q, %q), want=(%q, %q)",
+					tc.input,
+					actualDepID,
+					actualDepKey,
+					tc.expectedDepID,
+					tc.expectedDepKey))
 			}
 		})
 	}

--- a/controlplane/taskworker.go
+++ b/controlplane/taskworker.go
@@ -594,10 +594,10 @@ func mergeValueMapsToJson(src map[string]json.RawMessage, dependencies TaskDepen
 		}
 
 		for _, k := range dependencies[depID] {
-			if _, ok := temp[k]; !ok {
+			if _, ok := temp[k.DependencyKey]; !ok {
 				continue
 			}
-			out[k] = temp[k]
+			out[k.TaskKey] = temp[k.DependencyKey]
 		}
 	}
 	return json.Marshal(out)

--- a/controlplane/types.go
+++ b/controlplane/types.go
@@ -277,7 +277,7 @@ type ServiceCallingPlan struct {
 type ParallelGroup []string
 
 type DependencyKeySet map[string]struct{}
-type TaskDependenciesWithKeys map[string][]string
+type TaskDependenciesWithKeys map[string][]TaskDependencyMapping
 
 // SubTask represents a single task in the ServiceCallingPlan
 type SubTask struct {
@@ -287,6 +287,11 @@ type SubTask struct {
 	Input          map[string]any `json:"input"`
 	Status         Status         `json:"status,omitempty"`
 	Error          string         `json:"error,omitempty"`
+}
+
+type TaskDependencyMapping struct {
+	TaskKey       string `json:"taskKey"`
+	DependencyKey string `json:"dependencyKey"`
 }
 
 type ParamMapping struct {


### PR DESCRIPTION
## Bug fix

This allows the following to work:

```
orra verify run 'I am interested in this product when can I receive it?' \
--data custID:'cust4321' \
--data productDesc:'Peanuts collectible Swatch'
```

- `custID` maps to `customerID` in the execution plan, and now its value will be injected into `customerID` correctly.
- `productDesc` maps to `productDescription` in the execution plan, and now its value will be injected into `productDescription ` correctly.

### Previous workaround

The action params needed to be named exactly as the plan's task input params.