### PR TITLE
Cache hits should take action params into account during similarity matching

### DIFF
--- a/controlplane/orchestrate.go
+++ b/controlplane/orchestrate.go
@@ -508,8 +508,8 @@ func (s Spec) String() (string, error) {
 	return string(data), nil
 }
 
-func (a ActionParams) Json() (json.RawMessage, error) {
-	data, err := json.Marshal(a)
+func (p ActionParams) Json() (json.RawMessage, error) {
+	data, err := json.Marshal(p)
 	if err != nil {
 		return nil, err
 	}

--- a/controlplane/types.go
+++ b/controlplane/types.go
@@ -300,22 +300,24 @@ type TaskZeroCacheMapping struct {
 	Value       string `json:"originalValue,omitempty"` // Original value used to discover the mapping
 }
 
+type TaskZeroCacheMappings []TaskZeroCacheMapping
+
 type CacheEntry struct {
-	ID            string
-	Response      string
-	ActionVector  *mat.VecDense
-	ServicesHash  string
-	Task0Input    json.RawMessage
-	CacheMappings []TaskZeroCacheMapping
-	Timestamp     time.Time
-	Action        string
+	ID                     string
+	Response               string
+	ActionVector           *mat.VecDense
+	ServicesHash           string
+	Task0Input             json.RawMessage
+	CacheMappings          TaskZeroCacheMappings
+	Timestamp              time.Time
+	CachedActionWithFields string
 }
 
 type CacheResult struct {
 	Response      string
 	ID            string
 	Task0Input    json.RawMessage
-	CacheMappings []TaskZeroCacheMapping
+	CacheMappings TaskZeroCacheMappings
 	Hit           bool
 }
 


### PR DESCRIPTION
For Orra, these two actions are different, even though they share the same action text, because they have different action params. They should force fresh execution, unless a similar action with the exact params has been previously cached.

Note: **`customerID`** vs **`custID`**

1. Action params: **`customerID`** and `productDescription`

```sh
orra verify run 'I am interested in this product when can I receive it?' \
--data customerID:'cust4321' \
--data productDescription:'Peanuts collectible Swatch'
```

2. Action params: **`custID`** and `productDescription`

```sh
orra verify run 'I am interested in this product when can I receive it?' \
--data custID:'cust4321' \
--data productDescription:'Peanuts collectible Swatch'
```